### PR TITLE
CROWDEEG-66 Change Error Message of Graph Tooltip to be More Descriptive

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -4577,8 +4577,8 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
                 "<b>" + label + "</b>"+
                 "<br/> Y-value: " + realY +
                 "<br/> Duration: " + duration;
-            } catch {
-              return "Error";
+            } catch(err) {
+              return "Error Displaying Tooltip: " + err.message;
             }
           },
         },


### PR DESCRIPTION
If an error occurs during tooltip rendering, the JS error message is now displayed to the user. I was unable to cause an error during normal workflow, so it was tested by intentionally throwing an error in the try body.