### PR TITLE
CROWDEEG-75-Fix-Data-Filters

### DIFF
--- a/client/Data/index.html
+++ b/client/Data/index.html
@@ -17,16 +17,22 @@
                 </div>
             </div> -->
             <div class="col s12 m9">
-              <div class="row">
+              <!--div class="row">
                 <label>Path</label>
                 <input id="path">
                 <label>Patient #</label>
                 <input id="patientId">
               </div>
-              <button class="change-page" id="change-page">Change Data</button>
+              <button class="change-page" id="change-page">Change Data</button -->
               <br>
               <br>
               <div class="row">
+                <div class="col s12 m6">{{> reactiveTableFilter id="filterDataPath" label="Path"
+                    fields=filterFieldsDataPath }}
+                </div>
+                <div class="col s12 m6">{{> reactiveTableFilter id="filterPatientId" label="Patient #"
+                    fields=filterFieldsPatientId }}
+                </div>
                 <div class="col s12 m6">{{> reactiveTableFilter id="filterPatientAge" label="Age" fields=filterFieldsPatientAge }}
                 </div>
                 <div class="col s12 m6">{{> reactiveTableFilter id="filterNumAssignments" label="# Assignments"

--- a/client/Data/index.html
+++ b/client/Data/index.html
@@ -23,7 +23,7 @@
                 <label>Patient #</label>
                 <input id="patientId">
               </div>
-              <button class="change-page" id="change-page">Change Data</button -->
+              <button class="change-page" id="change-page">Change Data</button-->
               <br>
               <br>
               <div class="row">

--- a/client/Data/index.js
+++ b/client/Data/index.js
@@ -357,16 +357,18 @@ Template.Data.events({
   },
   'click .change-page'(event, template) {
     template.change.set(false)
+    console.log(document.getElementById('page'))
     page = parseInt(document.getElementById('page').value);
+    console.log(document);
     limit = parseInt(document.getElementById('limit').value);
     cond = {};
-    let patientId = document.getElementById('patientId').value;
-    let path = document.getElementById('path').value;
+    let patientId = document.getElementById('patientId') ? document.getElementById('patientId').value : null;
+    let path = document.getElementById('path') ? document.getElementById('path').value : null;
     //console.log(path);
     if (patientId) cond["name"] = patientId;
     if (path) cond["path"] = path;
     //console.log(cond);
-    //console.log(template);
+    console.log(template);
     Meteor.setTimeout(() => (template.change.set(true)), 1000);
   },
   'autocompleteselect input.assignee'(event, template, user) {
@@ -590,7 +592,11 @@ Template.Data.events({
 Template.Data.helpers({
   settings() {
     const selectedData = Template.instance().selectedData;
-    const data = Data.find(cond, { skip: (page - 1) * limit, limit: limit }).fetch();
+    console.log("start");
+    console.log(Data);
+    const data = Data.find(cond, { skip: (page - 1) * limit}).fetch();
+    console.log(data);
+    console.log(page);
     data.forEach((d) => {
       d.lengthFormatted = d.lengthFormatted();
       d.lengthInSeconds = d.lengthInSeconds();
@@ -863,4 +869,12 @@ Template.Data.onCreated(function () {
   this.selectedAssignees = new ReactiveVar({});
   this.change = new ReactiveVar(true);
   this.align = new ReactiveVar(true);
+  this.change.set(false);
+  //console.log(document.getElementById('page'))
+  //page = parseInt(document.getElementById('page').value);
+  //console.log(document.getElementById('recordings'));
+  //this.change.get();
+  //limit = parseInt(document.getElementById('limit').value);
+  Meteor.setTimeout(() => (this.change.set(true)), 1000);
+  console.log(this);
 });

--- a/client/Data/index.js
+++ b/client/Data/index.js
@@ -362,8 +362,11 @@ Template.Data.events({
     cond = {};
     let patientId = document.getElementById('patientId').value;
     let path = document.getElementById('path').value;
+    //console.log(path);
     if (patientId) cond["name"] = patientId;
     if (path) cond["path"] = path;
+    //console.log(cond);
+    //console.log(template);
     Meteor.setTimeout(() => (template.change.set(true)), 1000);
   },
   'autocompleteselect input.assignee'(event, template, user) {

--- a/client/Data/index.js
+++ b/client/Data/index.js
@@ -869,12 +869,5 @@ Template.Data.onCreated(function () {
   this.selectedAssignees = new ReactiveVar({});
   this.change = new ReactiveVar(true);
   this.align = new ReactiveVar(true);
-  this.change.set(false);
-  //console.log(document.getElementById('page'))
-  //page = parseInt(document.getElementById('page').value);
-  //console.log(document.getElementById('recordings'));
-  //this.change.get();
-  //limit = parseInt(document.getElementById('limit').value);
-  Meteor.setTimeout(() => (this.change.set(true)), 1000);
-  console.log(this);
+  //console.log(this);
 });


### PR DESCRIPTION
Added HTML filters so that Path and Patient # no longer need to be specified using the full string

Before when page refreshes, the table would only render 10 items (the default limit) and you would have had to click "Next Page" for it to re-render. Now it correctly renders all items when going onto the page (could have been Rosa's problem when not being able to see the files she uploaded as she had over the limit 10).