### PR TITLE
CROWDEEG-15 Add Unalignable Option to Alignments

### DIFF
--- a/server/EDFBackend.js
+++ b/server/EDFBackend.js
@@ -787,8 +787,8 @@ Meteor.methods({
     var currDataFrame;
     dataFrame = allRecordings.reduce((collections, recording) => {
       // accumulate all the data from all recordings into one dataFrame object
-      let startTimeAfterAdjustment = channelTimeshift[recording._id] && channelTimeshift[recording._id] !== "unalignable"
-        ? startTime + channelTimeshift[recording._id]
+      let startTimeAfterAdjustment = channelTimeshift[recording._id] && channelTimeshift[recording._id].timeshift
+        ? startTime + channelTimeshift[recording._id].timeshift
         : startTime;
 
       currDataFrame = WFDB.rdsamp({

--- a/server/EDFBackend.js
+++ b/server/EDFBackend.js
@@ -787,7 +787,7 @@ Meteor.methods({
     var currDataFrame;
     dataFrame = allRecordings.reduce((collections, recording) => {
       // accumulate all the data from all recordings into one dataFrame object
-      let startTimeAfterAdjustment = channelTimeshift[recording._id]
+      let startTimeAfterAdjustment = channelTimeshift[recording._id] && channelTimeshift[recording._id] !== "unalignable"
         ? startTime + channelTimeshift[recording._id]
         : startTime;
 


### PR DESCRIPTION
Allows datasets to be marked as unalignable, preventing changes to alignment and being represented as an 'unalignable' property in the corresponding channelTimeshift object.

To mark a dataset as unalignable, select the "Toggle Unalignable" time sync option and click on any channel data in the graph (similar to aligning by crosshair). The corresponding dataset will be marked. This change is breaking to old alignment files, however if needed support can be added for reading those as well!