### PR TITLE
CROWDEEG-93 Fix File Ids

### DIFF
--- a/client/Data/index.js
+++ b/client/Data/index.js
@@ -1,4 +1,4 @@
-import { Data, Tasks, Assignments, Patients} from '/collections';
+import { Data, Tasks, Assignments, Patients, getFileId} from '/collections';
 import moment from 'moment';
 import { MaterializeModal } from '/client/Modals/modal.js'
 import { EDFFile } from '/collections';
@@ -142,7 +142,7 @@ let assembleTaskObj = (signalNameSet, source, file) => {
 let deleteFile = (fileName) => {
   return new Promise((resolve, reject) => {
     let patient = Patients.findOne({id:"Unspecified Patient - "+ fileName });
-    let fileId = fileName.split(".")[0].replace(/\W/g, '');
+    let fileId = getFileId(fileName);
     if (patient) {
       let patient_id = patient["_id"];
       console.log(patient_id);
@@ -275,7 +275,7 @@ Template.Data.events({
 
           // Since EDFFile is a promise, we need to handle it as such
           EDFFile.then(result => {
-            let fileId = input.name.split('.')[0].replace(/\W/g, '');
+            let fileId = getFileId(input.name);
 
             let checkIfFileExists = new Promise((resolve, reject) => {
               Meteor.call("get.file.exists", fileId,
@@ -352,7 +352,6 @@ Template.Data.events({
                   }
                 } else {
                   // window.alert('File "' + fileObj.name + '" successfully uploaded');
-                  console.log(uploadInstance.config.fileId);
   
                   const recordingPath = `/uploaded/${uploadInstance.config.fileId}.edf`;
   
@@ -427,7 +426,7 @@ Template.Data.events({
               }
             });
           }).catch(error => {
-            console.log("Upload Process Failed")
+            console.log("Upload Process Failed: ", error);
           });
 
 

--- a/collections/index.js
+++ b/collections/index.js
@@ -1,4 +1,5 @@
 import { Match } from 'meteor/check'
+import { helpers } from 'meteor/ostrio:files';
 import moment, { relativeTimeRounding } from 'moment'
 import swal from 'sweetalert2'
 import seedrandom from 'seedrandom'
@@ -2502,7 +2503,6 @@ env_p = new Promise ((resolve,reject)=>{
 
 // We chain the then blocks, as we cannot instantiate EDFFile before we have edf_dir
 exports.EDFFile = env_p.then(result =>{
-        console.log(result);
         var edf_dir = result;
     
         console.log(edf_dir);
@@ -2520,6 +2520,14 @@ exports.EDFFile = env_p.then(result =>{
         
     })
     .catch(error => console.log(error))
+
+exports.getFileId = (fileName) => {
+
+    /* helpers.sanitize is how ids are sanitized in the ostrio:files import, in server.js of their github repository.
+       This is done since we construct file ids based on their name, so to replicate we need to sanitize the same way.
+       (Note the split and replace is our own sanitization). */
+    return helpers.sanitize(fileName.split('.')[0].replace(/\W/g, ''), 20, 'a');
+};
 
 
 Meteor.startup(() => {

--- a/server/EDFBackend.js
+++ b/server/EDFBackend.js
@@ -1,6 +1,6 @@
 import { dsvFormat } from "d3-dsv";
 import { Mongo } from "meteor/mongo";
-import { Data, Assignments,EDFFile} from "/collections";
+import { Data, Assignments,EDFFile, sanitize} from "/collections";
 
 String.prototype.toPascalCase = function () {
 	return this.replace(/\s(.)/g, function ($1) {


### PR DESCRIPTION
The issue with this fix is that the values in the call to helpers.sanitize() are hardcoded to be consistent with those of the ostrio:files library. Changes to that library (specifically if the maximum fileId length is reduced) may be a breaking change. 

As a solution, we could provide our own sanitization function which restricts parameter inputs - what are your thoughts on that?