### PR TITLE
CROWDEEG-82-Make-Default-Box-Label-Same-As-Previous

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -475,7 +475,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     // initializing variables for future usage by the functions
     var that = this;
     that.vars = {
-      previousAnnotationLabel: null,
+      previousAnnotationLabelBox: null,
       currentTimeDiff: 0,
       annotationClicks: {
         clickOne: null,
@@ -4121,7 +4121,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     var original_series = [];
     /* plot all of the points to the chart */
     var that = this;
-    console.log(that.vars.previousAnnotationLabel);
+    console.log(that.vars.previousAnnotationLabelBox);
     // if the chart object does not yet exist, because the user is loading the page for the first time
     // or refreshing the page, then it's necessary to initialize the plot area
     if (!that.vars.chart) {
@@ -7435,12 +7435,12 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     }
     console.log(annotation.metadata.annotationLabel);
     console.log(this);
-    if(annotation.metadata.annotationLabel === undefined){
-      console.log(this.vars.previousAnnotationLabel);
-      annotation.metadata.annotationLabel = this.vars.previousAnnotationLabel;
+    if(annotation.metadata.annotationLabel === undefined && annotation.metadata.displayType === "Box"){
+      console.log(this.vars.previousAnnotationLabelBox);
+      annotation.metadata.annotationLabel = this.vars.previousAnnotationLabelBox;
     }
 
-    console.log(annotation.metadata.annotationLabel);
+    console.log(annotation.metadata.previousAnnotationLabelBox);
     // console.log(that.vars.universalChangePointAnnotations.map(a => that._getAnnotationXMinFixed(a)));
     // console.log(that.vars.universalChangePointAnnotationsCache.map(a => that._getAnnotationXMinFixed(a)));
   },
@@ -9542,8 +9542,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       }
       that.vars.annotationsCache[key] = cacheEntry;
       //that.vars.previousAnnotationLabel = annotationLabel;
-      if(annotationLabel != undefined){
-        that.vars.previousAnnotationLabel = annotationLabel;
+      console.log(annotation);
+      const boxVals = [undefined, "Obstructive Apnea", "Central Apnea", "Obstructive Hypoapnea", "Central Hypoapnea", "Flow Limitation", "Cortical Arousal", "Autonomic Arousal", "Desat. Event", "Mixed Apnea", "Mixed Hypoapnea", "(unanalyzable)"];
+      if(annotationLabel != undefined && boxVals.includes(annotationLabel)){
+        that.vars.previousAnnotationLabelBox = annotationLabel;
       }
       callback && callback(annotation, null);
     }

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -475,6 +475,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     // initializing variables for future usage by the functions
     var that = this;
     that.vars = {
+      previousAnnotationLabel: null,
       currentTimeDiff: 0,
       annotationClicks: {
         clickOne: null,
@@ -4120,7 +4121,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     var original_series = [];
     /* plot all of the points to the chart */
     var that = this;
-
+    console.log(that.vars.previousAnnotationLabel);
     // if the chart object does not yet exist, because the user is loading the page for the first time
     // or refreshing the page, then it's necessary to initialize the plot area
     if (!that.vars.chart) {
@@ -6397,13 +6398,16 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
         mouseleave: function (event) {
           that.vars.selectedAnnotation = undefined;
+          console.log("hehehe")
         },
 
         mouseup: function (event) {
           var element = $(this.group.element);
           var annotation = this;
+          console.log("hellp")
 
           element.mouseout(event => {
+            console.log("ioioioio")
             that._saveFeatureAnnotation(annotation);
             element.off('mouseout');
             element.off('mouseup');
@@ -6807,8 +6811,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     form.submit(function (event) {
       event.preventDefault();
       var collapsed = toggleButton.hasClass("fa-pencil");
+      console.log(collapsed);
       if (collapsed) {
         toggleButton.removeClass("fa-pencil").addClass("fa-floppy-o");
+        console.log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
         input.show().focus();
         annotationLabelSelector.show();
         $(".changePointLabelRight").hide();
@@ -6816,7 +6822,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         that.vars.chart.tooltip.label.hide();
 
       } else {
-
+        console.log("BBBBBBBBBBBBBBBBBBBBBBBBBBb")
 
         //////
         $(".changePointLabelRight").show();
@@ -6827,6 +6833,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         annotationLabelSelector.hide();
         var comment = input.val();
         var annotationLabel = annotationLabelSelector.val();
+        console.log(annotationLabel);
         toggleButton.focus();
         annotations
           .filter((a) => a.metadata.id == annotation.metadata.id)
@@ -6838,6 +6845,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
             //gets the label from the form selector
             $(a.group.element).find(".form-control").val(annotationLabel);
           });
+        console.log("here")
         that._saveFeatureAnnotation(annotation);
         that.vars.chart.tooltip.label.show();
       }
@@ -7294,6 +7302,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
   _saveFeatureAnnotation: function (annotation) {
     var that = this;
+    console.log(that);
 
     var annotationId = annotation.metadata.id;
     var type = annotation.metadata.featureType;
@@ -7376,12 +7385,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       that._updateControlPoint(annotation);
     }
 
-
     // convert changepoint annotations to box annotations where neccesary.
     if (annotation.metadata.annotationLabel == '(end previous state)') {
       that._convertChangePointsToBox(annotation);
     }
-
 
     // if (annotation.metadata.displayType == 'ChangePoint' || annotation.metadata.displayType == 'ChangePointAll') {
     that._updateChangePointLabelRight(annotation);
@@ -7426,7 +7433,14 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       })
       that._saveFeatureAnnotation(annotation);
     }
+    console.log(annotation.metadata.annotationLabel);
+    console.log(this);
+    if(annotation.metadata.annotationLabel === undefined){
+      console.log(this.vars.previousAnnotationLabel);
+      annotation.metadata.annotationLabel = this.vars.previousAnnotationLabel;
+    }
 
+    console.log(annotation.metadata.annotationLabel);
     // console.log(that.vars.universalChangePointAnnotations.map(a => that._getAnnotationXMinFixed(a)));
     // console.log(that.vars.universalChangePointAnnotationsCache.map(a => that._getAnnotationXMinFixed(a)));
   },
@@ -9483,6 +9497,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         rationale: rationale,
       };
       that._addArbitrationInformationToObject(annotationModifier);
+      console.log(that.vars);
       //TODO: BUG HERE - if the with regards to id
       // console.log(annotationModifier);
       Annotations.update(
@@ -9526,6 +9541,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         cacheEntry.annotations.unshift(annotation.value);
       }
       that.vars.annotationsCache[key] = cacheEntry;
+      //that.vars.previousAnnotationLabel = annotationLabel;
+      if(annotationLabel != undefined){
+        that.vars.previousAnnotationLabel = annotationLabel;
+      }
       callback && callback(annotation, null);
     }
   },

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -6846,6 +6846,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
             $(a.group.element).find(".form-control").val(annotationLabel);
           });
         console.log("here")
+        const boxVals = [undefined, "Obstructive Apnea", "Central Apnea", "Obstructive Hypoapnea", "Central Hypoapnea", "Flow Limitation", "Cortical Arousal", "Autonomic Arousal", "Desat. Event", "Mixed Apnea", "Mixed Hypoapnea", "(unanalyzable)"];
+        if(annotation.metadata.displayType === "Box"){
+          that.vars.previousAnnotationLabelBox = annotationLabel;
+        }
         that._saveFeatureAnnotation(annotation);
         that.vars.chart.tooltip.label.show();
       }
@@ -7757,6 +7761,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
   },
 
   _getAnnotationXMinFixed: function (annotation) {
+    console.log(annotation);
     return parseFloat(annotation.options.xValue).toFixed(2);
   },
 
@@ -9541,12 +9546,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         cacheEntry.annotations.unshift(annotation.value);
       }
       that.vars.annotationsCache[key] = cacheEntry;
-      //that.vars.previousAnnotationLabel = annotationLabel;
-      console.log(annotation);
-      const boxVals = [undefined, "Obstructive Apnea", "Central Apnea", "Obstructive Hypoapnea", "Central Hypoapnea", "Flow Limitation", "Cortical Arousal", "Autonomic Arousal", "Desat. Event", "Mixed Apnea", "Mixed Hypoapnea", "(unanalyzable)"];
-      if(annotationLabel != undefined && boxVals.includes(annotationLabel)){
-        that.vars.previousAnnotationLabelBox = annotationLabel;
-      }
       callback && callback(annotation, null);
     }
   },

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -2923,6 +2923,9 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
           return;
         }
         annotation.metadata.annotationLabel = feature;
+        if(annotation.metadata.displayType === "Box"){
+          that.vars.previousAnnotationLabelBox = feature;
+        }
         that._saveFeatureAnnotation(annotation);
       }
 
@@ -3993,6 +3996,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
   _applyFrequencyFilters: function (data, callback) {
     var that = this;
+    //console.log(this.vars.chart);
     var numRemainingChannelsToFilter = data.channels.length;
     var maxDetectableFrequencyInHz = data.sampling_rate / 2;
     var frequencyFilters = that.vars.frequencyFilters || [];
@@ -6253,7 +6257,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
     that._saveFeatureAnnotation(annotation);
     that._addChangePointLabelRight(annotation);
-    console.log(annotation);
+    //console.log(annotation);
     return annotation;
   },
 
@@ -6294,7 +6298,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     that._addChangePointLabelLeft(annotation);
 
 
-    console.log(annotation);
+    //console.log(annotation);
     return annotation;
   },
 
@@ -6398,16 +6402,20 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
         mouseleave: function (event) {
           that.vars.selectedAnnotation = undefined;
-          console.log("hehehe")
+          //console.log("hehehe")
         },
 
         mouseup: function (event) {
           var element = $(this.group.element);
           var annotation = this;
-          console.log("hellp")
+          //console.log("hellp")
+          //console.log("ioioioio")
+          //console.log(annotation);
+
+          that._saveFeatureAnnotation(annotation);
+
 
           element.mouseout(event => {
-            console.log("ioioioio")
             that._saveFeatureAnnotation(annotation);
             element.off('mouseout');
             element.off('mouseup');
@@ -6814,7 +6822,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       console.log(collapsed);
       if (collapsed) {
         toggleButton.removeClass("fa-pencil").addClass("fa-floppy-o");
-        console.log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        //console.log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
         input.show().focus();
         annotationLabelSelector.show();
         $(".changePointLabelRight").hide();
@@ -6822,7 +6830,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         that.vars.chart.tooltip.label.hide();
 
       } else {
-        console.log("BBBBBBBBBBBBBBBBBBBBBBBBBBb")
+        //console.log("BBBBBBBBBBBBBBBBBBBBBBBBBBb")
 
         //////
         $(".changePointLabelRight").show();
@@ -6833,9 +6841,9 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         annotationLabelSelector.hide();
         var comment = input.val();
         var annotationLabel = annotationLabelSelector.val();
-        console.log(annotationLabel);
+       // console.log(annotationLabel);
         toggleButton.focus();
-        annotations
+         annotations
           .filter((a) => a.metadata.id == annotation.metadata.id)
           .forEach((a) => {
             a.metadata.comment = comment;
@@ -6845,13 +6853,13 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
             //gets the label from the form selector
             $(a.group.element).find(".form-control").val(annotationLabel);
           });
-        console.log("here")
-        const boxVals = [undefined, "Obstructive Apnea", "Central Apnea", "Obstructive Hypoapnea", "Central Hypoapnea", "Flow Limitation", "Cortical Arousal", "Autonomic Arousal", "Desat. Event", "Mixed Apnea", "Mixed Hypoapnea", "(unanalyzable)"];
+        //console.log("here");
         if(annotation.metadata.displayType === "Box"){
           that.vars.previousAnnotationLabelBox = annotationLabel;
         }
         that._saveFeatureAnnotation(annotation);
         that.vars.chart.tooltip.label.show();
+        //console.log('CCCCCCCCCCCCCCCCCCCCCC');
       }
     });
 
@@ -7306,7 +7314,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
   _saveFeatureAnnotation: function (annotation) {
     var that = this;
-    console.log(that);
+    //console.log(that);
 
     var annotationId = annotation.metadata.id;
     var type = annotation.metadata.featureType;
@@ -7437,14 +7445,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       })
       that._saveFeatureAnnotation(annotation);
     }
-    console.log(annotation.metadata.annotationLabel);
-    console.log(this);
     if(annotation.metadata.annotationLabel === undefined && annotation.metadata.displayType === "Box"){
       console.log(this.vars.previousAnnotationLabelBox);
       annotation.metadata.annotationLabel = this.vars.previousAnnotationLabelBox;
     }
-
-    console.log(annotation.metadata.previousAnnotationLabelBox);
     // console.log(that.vars.universalChangePointAnnotations.map(a => that._getAnnotationXMinFixed(a)));
     // console.log(that.vars.universalChangePointAnnotationsCache.map(a => that._getAnnotationXMinFixed(a)));
   },
@@ -7761,7 +7765,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
   },
 
   _getAnnotationXMinFixed: function (annotation) {
-    console.log(annotation);
+    //console.log(annotation);
     return parseFloat(annotation.options.xValue).toFixed(2);
   },
 
@@ -9502,7 +9506,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         rationale: rationale,
       };
       that._addArbitrationInformationToObject(annotationModifier);
-      console.log(that.vars);
+      //console.log(that.vars);
       //TODO: BUG HERE - if the with regards to id
       // console.log(annotationModifier);
       Annotations.update(


### PR DESCRIPTION
New box annotations now default to the previous box annotation label. Just make the box then move the cursor away.

However, sometimes when making the box and dragging the box past the bottom of the graph, it fails to render, but this would not be an issue when using the app normally.