### PR TITLE
CROWDEEG-85-Save-Preferences

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -785,6 +785,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
                             </div>\
                         </div> \
                         <div style="margin-bottom: 20px; margin-left: 20px; margin-right: 20px" class="io_panel"> \
+                            <b> Annotations: </b>&nbsp\
                             <button type="button" id="annotation_save" class="btn btn-default fa fa-save" ></button>&nbsp\
                             <button type="button" id="annotation_download" class="btn btn-default fa fa-download" ></button>&nbsp\
                             <button type="button" id="annotation_upload" class="btn btn-default fa fa-upload" ></button>&nbsp\
@@ -847,8 +848,8 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
                     </div> \
                 </div> \
             </div> \
-            <div style="position: relative; left: 38%" class="preferences_panel"> \
-                <b> Preferences </b>:\
+            <div style="display: flex; margin-bottom: 20px; margin-left: 30px; margin-right: 20px; flex-flow: row" class="preferences_panel"> \
+                <b> Preferences: </b>&nbsp\
                 <button type="button" id="preferences_save" class="btn btn-default fa fa-save" ></button>&nbsp\
                 <button type="button" id="preferences_download" class="btn btn-default fa fa-download" ></button>&nbsp\
                 <button type="button" id="preferences_upload" class="btn btn-default fa fa-upload" ></button>&nbsp\

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -785,7 +785,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
                             </div>\
                         </div> \
                         <div style="margin-bottom: 20px; margin-left: 20px; margin-right: 20px" class="io_panel"> \
-                            <b> Annotations: </b>&nbsp\
+                            <b> Annotations/Alignment: </b>&nbsp\
                             <button type="button" id="annotation_save" class="btn btn-default fa fa-save" ></button>&nbsp\
                             <button type="button" id="annotation_download" class="btn btn-default fa fa-download" ></button>&nbsp\
                             <button type="button" id="annotation_upload" class="btn btn-default fa fa-upload" ></button>&nbsp\
@@ -850,7 +850,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
             </div> \
             <div style="display: flex; margin-bottom: 20px; margin-left: 30px; margin-right: 20px; flex-flow: row" class="preferences_panel"> \
                 <b> Preferences: </b>&nbsp\
-                <button type="button" id="preferences_save" class="btn btn-default fa fa-save" ></button>&nbsp\
+                <button type="button" id="preferences_save" class="btn btn-default fa fa-save"></button>&nbsp\
                 <button type="button" id="preferences_download" class="btn btn-default fa fa-download" ></button>&nbsp\
                 <button type="button" id="preferences_upload" class="btn btn-default fa fa-upload" ></button>&nbsp\
                 <input type="file" accept=".json" id="PreferencesFile">\
@@ -2710,18 +2710,34 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     element
       .find("#preferences_upload")
       .click(function () {
-        that._parsePreferencesJsonFile();
+        try{
+          that._parsePreferencesJsonFile();
+          window.alert("Upload Successful. Please click the save button to view the changes.");
+        } catch(error){
+          window.alert("An error occured: " + error + ". Please try uploading a different file");
+        }
+        
       });
 
+    
     element
       .find("#preferences_save")
       .click(function () {
-        console.log(that.options.context.preferences.uploadedPreferences);
-        that._savePreferences(that.options.context.preferences.uploadedPreferences);
-        //console.log(that.options.context.preferences.annotatorConfig);
-        //reload the screen so we can actually view the preferences
-        location.reload();
+        console.log(Object.keys(that.options.context.preferences.uploadedPreferences.scalingFactors).length);
+        console.log(Object.keys(that.vars.originalScalingFactors).length);
+        //if the scaling factors length of the uploaded file does not match the scaling 
+        //factors of the chart, they they are not compatible
+        if(that.options.context.preferences.uploadedPreferences.scalingFactors != null){
+          if(Object.keys(that.options.context.preferences.uploadedPreferences.scalingFactors).length != Object.keys(that.vars.originalScalingFactors).length){
+            window.alert("The preferences file you uploaded is not compatible with the chart (number of channels do not match). Please choose another file.");
+          } else {
+            that._savePreferences(that.options.context.preferences.uploadedPreferences);
+            //reload the screen so we can view the changes
+            location.reload();
+          }
+        }
       });
+      
   },
 
   _isInCrosshairWindow: function (crosshair) {

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -4259,6 +4259,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       if(that.options.context.preferences.annotatorConfig.scalingFactors != null){
         that.vars.scalingFactors = that.options.context.preferences.annotatorConfig.scalingFactors;
       }
+      //console.log(that.vars.translation);
       //add translations
       if(that.options.context.preferences.annotatorConfig.translations != null){
         that.vars.translation = that.options.context.preferences.annotatorConfig.translations;
@@ -9939,8 +9940,18 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
   _downloadPreferencesJSON: function () {
     var that = this;
+    // if we are downloading the preferences for the initial graph, we need enough info
+    // so that when uploading the "default" preferences, the graph does go back to its initial state.
+    if(that.options.context.preferences.annotatorConfig.scalingFactors == null){
+      that.options.context.preferences.annotatorConfig.scalingFactors = that.vars.originalScalingFactors;
+    } 
+    if(that.options.context.preferences.annotatorConfig.maskedChannels == null){
+      that.options.context.preferences.annotatorConfig.maskedChannels = [];
+    }
+    if(that.options.context.preferences.annotatorConfig.translations == null){
+      that.options.context.preferences.annotatorConfig.translations = {};
+    }
     var obj = that.options.context.preferences.annotatorConfig;
-    
     var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(obj));
     var downloadAnchorNode = document.createElement('a');
     downloadAnchorNode.setAttribute("href", dataStr);


### PR DESCRIPTION
- Preferences are now saved, so when you reload a page the common filters (timescale, channel masking, limiting, amplitude, translation) remain.
- Note: time sync already seems to be included in the saved preferences
- Can also download and upload preferences, however there is no system in place to ensure that you are uploading compatible preferences. For example, if you upload preferences for a chart with 12 channels to a chart with 6 channels, there will be a rendering error.
- Should fix CROWDEEG-94, since the issue with the channels blowing up when changing amplitudes then switching pages has been resolved.
- when downloading the initial preferences (when you first start the task), these preferences should revert everything back to the way it was initially.
- When you save the changes, there will be a check to make sure that the file and the chart have the same number of channels. If not, then it is not compatible and wont save the preferences

