### PR TITLE
CROWDEEG-96-Fix-Annotation-Manager

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -1527,6 +1527,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     //console.log("_setup.that:", that);
     that._adaptContent();
     that._setupAnnotationManager();
+    that._startAnnotationManagerEvents();
     that._setupTimer();
     that._setupFeaturePanel();
     that._setupNavigationPanel();
@@ -10369,6 +10370,73 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     return false;
   },
 
+  _startAnnotationManagerEvents: function(){
+    that = this;
+    $(that.element).find(".annotation_manager_delete_btn").click(function(){
+      console.log("annotation manager delete button");
+      let annotations = that._getAnnotationsOnly();
+      //let i = select.val();
+      let i = $(that.element).find(".annotation_managerselect_panel :selected").val();
+
+      console.log(i);
+      var tbdeleted;
+      //deletes all of em
+      if(tbdeleted = annotations.find((el) => el.id == i)){
+        console.log("heere")
+        console.log(tbdeleted);
+        that._nukeAnnotation2(tbdeleted);
+        that._getAnnotations();
+      } else {
+        console.log("couldnt delete");
+      }
+      /*
+      annotations.forEach((annotation)=>{
+        console.log(annotation.id);
+        if(annotation.id == i){
+          tbdeleted = annotation;
+        }
+      })
+      console.log("heere")
+      console.log(tbdeleted);
+      that._nukeAnnotation2(tbdeleted);
+      that._getAnnotations();
+      */
+    })
+
+    $(that.element).find(".annotation_manager_view_btn").click(function(){
+      console.log("clicked annotation manager view button");
+      let annotations = that._getAnnotationsOnly();
+      let i = $(that.element).find(".annotation_managerselect_panel :selected").val();
+      var tbviewed;
+      if(tbviewed = annotations.find((el) => el.id == i)){
+        var nextWindowSizeInSeconds = that.vars.xAxisScaleInSeconds;
+
+        that._switchToWindow(
+          that.options.allRecordings,
+          parseFloat(tbviewed.position.start),
+          nextWindowSizeInSeconds
+        )
+      } else{
+        console.log("couldnt view");
+      }
+      /*
+      annotations.forEach((annotation)=>{
+        if(annotation.id == id){
+          tbviewed = annotation;
+        }
+      })
+      console.log("here1");
+      var nextWindowSizeInSeconds = that.vars.xAxisScaleInSeconds;
+
+      that._switchToWindow(
+        that.options.allRecordings,
+        parseFloat(tbviewed.position.start),
+        nextWindowSizeInSeconds
+      )
+      */
+    })
+  },
+
   _setupAnnotationManager:function(){
     that = this;
     let annotations = that._getAnnotationsOnly();
@@ -10390,10 +10458,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     })
     select.material_select();
 
-    $(that.element).find(".annotation_managerselect_panel").click(function(){
-      console.log(select.val());
-    })
-
+    /*
     $(that.element).find(".annotation_manager_delete_btn").click(function(){
       console.log("annotation manager delete button");
       //let i = select.val();
@@ -10404,11 +10469,13 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       //deletes all of em
       if(tbdeleted = annotations.find((el) => el.id == i)){
         console.log("heere")
-      console.log(tbdeleted);
-      that._nukeAnnotation2(tbdeleted);
-      that._getAnnotations();
+        console.log(tbdeleted);
+        that._nukeAnnotation2(tbdeleted);
+        that._getAnnotations();
+      } else {
+        console.log("couldnt delete");
       }
-      /*
+      
       annotations.forEach((annotation)=>{
         console.log(annotation.id);
         if(annotation.id == i){
@@ -10419,7 +10486,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       console.log(tbdeleted);
       that._nukeAnnotation2(tbdeleted);
       that._getAnnotations();
-      */
+      
     })
 
     $(that.element).find(".annotation_manager_view_btn").click(function(){
@@ -10444,6 +10511,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       )
 
     })
+    */
     return;
 
 

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -1526,7 +1526,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     var that = this;
     //console.log("_setup.that:", that);
     that._adaptContent();
-    that._updateAnnotationManager();
+    that._setupAnnotationManager();
     that._setupTimer();
     that._setupFeaturePanel();
     that._setupNavigationPanel();
@@ -1843,7 +1843,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     }
     if (!that.vars.printedBox) {
       that.vars.printedBox = true;
-      that.__setupAnnotationChoice();
+      that._setupAnnotationChoice();
     }
     var selection = that.options.boxAnnotationUserSelection || [];
     selection.forEach((boxAnnotation, t) => {
@@ -10369,65 +10369,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     return false;
   },
 
-  // Annotation Manager is always running in the backgroud in case you click view/delete so
-  // we make a new function to improve the speed after making annotations
-  _updateAnnotationManager:function(){
-    that = this;
-    let annotations = that._getAnnotationsOnly();
-    console.log("updating annotation manager");
-    let container = that.element.find(".annotation_manager_container");
-    container.empty();
-    let selectContainer = $(
-      '<div class="annotation_managerselect_panel"><select></select></div>'
-    ).appendTo(that.element.find(".annotation_manager_container"));
-    let select = selectContainer.find("select");
-    annotations.sort((a,b)=> {return a.position.start - b.position.start}).forEach((annotation,i)=>{
-      if(annotation.metadata.annotationLabel != null){
-        let s = "Label: " + annotation.metadata.annotationLabel + ", Starting Position: " + annotation.position.start
-        select.append(`<option value=${annotation.id}` +
-        ">" +
-        s+
-        "</option>");
-        }
-    })
-    select.material_select();
-
-    $(that.element).find(".annotation_manager_delete_btn").click(function(){
-      console.log("annotation manager delete button");
-      let i = select.val();
-      var tbdeleted;
-      annotations.forEach((annotation)=>{
-        if(annotation.id == i){
-          tbdeleted = annotation;
-        }
-      })
-      console.log(tbdeleted);
-      that._nukeAnnotation2(tbdeleted);
-      that._getAnnotations();
-    })
-
-    $(that.element).find(".annotation_manager_view_btn").click(function(){
-      console.log("clicked annotation manager view button");
-      let id = select.val();
-      var tbviewed;
-      annotations.forEach((annotation)=>{
-        if(annotation.id == id){
-          tbviewed = annotation;
-        }
-      })
-      console.log("gggggg");
-      var nextWindowSizeInSeconds = that.vars.xAxisScaleInSeconds;
-
-      that._switchToWindow(
-        that.options.allRecordings,
-        parseFloat(tbviewed.position.start),
-        nextWindowSizeInSeconds
-      )
-
-    })
-    return;
-  },
-
   _setupAnnotationManager:function(){
     that = this;
     let annotations = that._getAnnotationsOnly();
@@ -10449,24 +10390,45 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     })
     select.material_select();
 
+    $(that.element).find(".annotation_managerselect_panel").click(function(){
+      console.log(select.val());
+    })
+
     $(that.element).find(".annotation_manager_delete_btn").click(function(){
       console.log("annotation manager delete button");
-      let i = select.val();
+      //let i = select.val();
+      let i = $(that.element).find(".annotation_managerselect_panel :selected").val();
+
+      console.log(i);
       var tbdeleted;
+      //deletes all of em
+      if(tbdeleted = annotations.find((el) => el.id == i)){
+        console.log("heere")
+      console.log(tbdeleted);
+      that._nukeAnnotation2(tbdeleted);
+      that._getAnnotations();
+      }
+      /*
       annotations.forEach((annotation)=>{
+        console.log(annotation.id);
         if(annotation.id == i){
           tbdeleted = annotation;
         }
       })
+      console.log("heere")
       console.log(tbdeleted);
       that._nukeAnnotation2(tbdeleted);
       that._getAnnotations();
+      */
     })
 
     $(that.element).find(".annotation_manager_view_btn").click(function(){
       console.log("clicked annotation manager view button");
       let id = select.val();
       var tbviewed;
+      if(tbviewed = annotations.find((el) => el.id == i)){
+        
+      }
       annotations.forEach((annotation)=>{
         if(annotation.id == id){
           tbviewed = annotation;

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -1526,7 +1526,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     var that = this;
     //console.log("_setup.that:", that);
     that._adaptContent();
-    that._setupAnnotationManager();
+    that._updateAnnotationManagerSelect();
     that._startAnnotationManagerEvents();
     that._setupTimer();
     that._setupFeaturePanel();
@@ -2928,7 +2928,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
           that.vars.previousAnnotationLabelBox = feature;
         }
         that._saveFeatureAnnotation(annotation);
-        that._setupAnnotationManager();
+        that._updateAnnotationManagerSelect();
       }
 
       // var featureClassButton = $(that.element)
@@ -6419,7 +6419,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
           element.mouseout(event => {
             that._saveFeatureAnnotation(annotation);
-            that._setupAnnotationManager();
+            that._updateAnnotationManagerSelect();
             element.off('mouseout');
             element.off('mouseup');
           });
@@ -6861,7 +6861,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
           that.vars.previousAnnotationLabelBox = annotationLabel;
         }
         that._saveFeatureAnnotation(annotation);
-        that._setupAnnotationManager();
+        that._updateAnnotationManagerSelect();
         that.vars.chart.tooltip.label.show();
         //console.log('CCCCCCCCCCCCCCCCCCCCCC');
       }
@@ -9477,7 +9477,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
           }
         }
       );
-      that._setupAnnotationManager();
+      that._updateAnnotationManagerSelect();
       // that.vars.annotationIDSet.add(annotationDocument.id);
 
       that._updateMarkAssignmentAsCompletedButtonState();
@@ -9579,7 +9579,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         return;
       }
     });
-    that._setupAnnotationManager();
+    that._updateAnnotationManagerSelect();
   },
 
   _incrementNumberOfAnnotationsInCurrentWindow: function (increment) {
@@ -10142,7 +10142,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     for (let i = 0; i < annotationsId.length; i++) {
       newAnnotations[i].id = annotationsId[i];
     }
-    that._setupAnnotationManager();
+    that._updateAnnotationManagerSelect();
     that._updateMarkAssignmentAsCompletedButtonState();
 
     for (let i = 0; i < newAnnotations.length; i++) {
@@ -10371,6 +10371,8 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
   },
 
   _startAnnotationManagerEvents: function(){
+    // here we separate the jQuery elements so that they are not being duplicated for each function call
+    // Thus this is only called ONCE at the begginning where we set everything up
     that = this;
     $(that.element).find(".annotation_manager_delete_btn").click(function(){
       console.log("annotation manager delete button");
@@ -10380,7 +10382,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
 
       console.log(i);
       var tbdeleted;
-      //deletes all of em
       if(tbdeleted = annotations.find((el) => el.id == i)){
         console.log("heere")
         console.log(tbdeleted);
@@ -10389,18 +10390,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       } else {
         console.log("couldnt delete");
       }
-      /*
-      annotations.forEach((annotation)=>{
-        console.log(annotation.id);
-        if(annotation.id == i){
-          tbdeleted = annotation;
-        }
-      })
-      console.log("heere")
-      console.log(tbdeleted);
-      that._nukeAnnotation2(tbdeleted);
-      that._getAnnotations();
-      */
     })
 
     $(that.element).find(".annotation_manager_view_btn").click(function(){
@@ -10419,25 +10408,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       } else{
         console.log("couldnt view");
       }
-      /*
-      annotations.forEach((annotation)=>{
-        if(annotation.id == id){
-          tbviewed = annotation;
-        }
-      })
-      console.log("here1");
-      var nextWindowSizeInSeconds = that.vars.xAxisScaleInSeconds;
-
-      that._switchToWindow(
-        that.options.allRecordings,
-        parseFloat(tbviewed.position.start),
-        nextWindowSizeInSeconds
-      )
-      */
     })
   },
 
-  _setupAnnotationManager:function(){
+  _updateAnnotationManagerSelect:function(){
     that = this;
     let annotations = that._getAnnotationsOnly();
     console.log("setting up annotation manager");
@@ -10449,7 +10423,14 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     let select = selectContainer.find("select");
     annotations.sort((a,b)=> {return a.position.start - b.position.start}).forEach((annotation,i)=>{
       if(annotation.metadata.annotationLabel != null){
-        let s = "Label: " + annotation.metadata.annotationLabel + ", Starting Position: " + annotation.position.start
+        // counldnt call a separate function so I added the time formatting here
+        var sec = annotation.position.start;
+        var h = Math.floor(sec / 3600);
+        sec -= h * 3600;
+        var m = Math.floor(sec / 60);
+        sec -= m * 60;
+        sec = Math.round(sec);
+        let s = "Label: " + annotation.metadata.annotationLabel + ", Starting Position: " + h + ":" + (m < 10 ? "0" + m : m) + ":" + (sec < 10 ? "0" + sec : sec)
         select.append(`<option value=${annotation.id}` +
         ">" +
         s+


### PR DESCRIPTION
The annotation labels in the manager now only include the annotationLabel and the start time. The delete and view functionalities are fixed and are faster due to the separation of the jQuery events from the select container updater. 
Note: If a function has jQuery events (ie $().click()....) then those events are running the whole time, so when we recall the function, these events are duplicated, which is most likely the reason for the slower times when shifting pages, since we call the _populateGraph function each time, hence the jQuery events are being duplicated => slow.