### PR TITLE
CROWDEEG-100 Optimise masking and page switching

### DIFF
--- a/server/EDFBackend.js
+++ b/server/EDFBackend.js
@@ -761,6 +761,7 @@ Meteor.methods({
     let startTime = options.start_time || 0;
     let windowLength = options.window_length;
     let count = 0;
+    let maskedChannels = options.maskedChannels;
 
     // this is the original version of codes which display all channels specified in the options:
     let channelsDisplayed = options.channels_displayed;
@@ -792,6 +793,7 @@ Meteor.methods({
     //   );
     //   channelsDisplayed[recording.source] = channelDisplayed.split(' ').slice(1, -1)
     // })
+    /*
     allRecordings.map((recording) => {
       const channelDisplayed = Data.findOne(
         recording._id
@@ -800,14 +802,15 @@ Meteor.methods({
         "-s"
       );
       channelsDisplayed[recording.source] = channelDisplayed
+      
     })
+    */
     allRecordings = allRecordings.map((recording) => {
       channelsDisplayed[recording.source] = Data.findOne(
         recording._id
       ).metadata.wfdbdesc.Groups[0].Signals.map(
         (signal) => "'" + signal.Description + "'"
       );
-
       recording.channelsDisplayedParsed = parseChannelsDisplayed(
         channelsDisplayed[recording.source],
         recording._id


### PR DESCRIPTION
Given that masking now hides the channel, instead of a selective channel display, we optimise page switching and masking by only updating unmasked channels, to speed up pagination when there are less channels. 
Also includes the separation of masking and unmasking given that the _switchToWindow function is called twice.