### PR TITLE
CROWDEEG-112 Update Annotations Cache

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -10631,6 +10631,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         return;
       }
     });
+    that.vars.annotationsCache = {};
     that._updateAnnotationManagerSelect();
   },
 


### PR DESCRIPTION
The annotations cache is no longer cleared when switching windows, and in some places the keys have been changed to be based on the window position instead of the annotation position. Cache length has also been capped at 15, with replacement based on farthest start time from the added element, similar to the window cache.

Additionally, we no longer save annotations when switching windows, and flushing annotations no longer clears the cache.