### PR TITLE
CROWDEEG-114 Fix Data Search

### DIFF
--- a/client/Data/index.js
+++ b/client/Data/index.js
@@ -1088,23 +1088,25 @@ Meteor.isClient && Template.registerHelper('TabularTables',TabularTables);
     name: "Data",
     collection: Data,
     columns: [
-      {data: "_id", title: "Path",
-        render:function(val) {
-          const data = Data.find({_id: val}).fetch();
-          let path = "";
-          let name = "";
-          data.forEach((d) => {
-            path = d.path;
-            name = d.name;
-          });
-          let pathEnd = path != null ? path.lastIndexOf("/") : -1;
-          return pathEnd === -1 ? name : path.substring(0, pathEnd + 1) + name;
+      {data: "name", title: "Name",
+        render:function(val, type, row) {
+          if (type === 'display') {
+            const data = Data.find({_id: row._id}).fetch();
+            let path = "";
+            data.forEach((d) => {
+              path = d.path;
+            });
+            let pathEnd = path != null ? path.lastIndexOf("/") : -1;
+            return pathEnd === -1 ? val : path.substring(0, pathEnd + 1) + val;
+          } else {
+            return val;
+          }
         }},
       {data: "metadata.wfdbdesc.Length", title: "Length",
         render:function(val){
           return val.split(" ")[0];
         }},
-      {data: "_id", title: "Patient #",
+      {data: "_id", title: "Patient #", searchable: false,
         render:function(val){
           const data = Data.find({_id: val}).fetch();
           let patientNum = "";
@@ -1114,7 +1116,7 @@ Meteor.isClient && Template.registerHelper('TabularTables',TabularTables);
           })
           return patientNum;
         }},
-      {data: "_id", title: "# Assignments", 
+      {data: "_id", title: "# Assignments", searchable: false, 
         render:function(val){
           if(val){
             const data = Data.find({_id: val}).fetch();
@@ -1125,7 +1127,7 @@ Meteor.isClient && Template.registerHelper('TabularTables',TabularTables);
             return numAssignments;
           }
         }},
-        {data: "_id", title: "# Assignments Completed", 
+        {data: "_id", title: "# Assignments Completed", searchable: false, 
         render:function(val){
           const data = Data.find({_id: val}).fetch();
           let numAssignmentsCompleted = 0;
@@ -1134,7 +1136,7 @@ Meteor.isClient && Template.registerHelper('TabularTables',TabularTables);
           })
           return numAssignmentsCompleted;
         }},
-        {data: "_id", title: "Assignees", 
+        {data: "_id", title: "Assignees", searchable: false, 
         render:function(val){
           const data = Data.find({_id: val}).fetch();
           let assignees = [];

--- a/server/DataTable.js
+++ b/server/DataTable.js
@@ -8,17 +8,25 @@ TabularTables.Data = new Tabular.Table({
     name: "Data",
     collection: Data,
     columns: [
-        {data: "_id", title: "Path",
-        render:function(val) {
-          const data = Data.find({_id: val}).fetch();
-          let pathEnd = data.path.lastIndexOf("/");
-          return pathEnd === -1 ? data.name : data.path.substring(0, pathEnd + 1) + data.name;
-        }},
+        {data: "name", title: "Name",
+          render:function(val, type, row) {
+            if (type === 'display') {
+              const data = Data.find({_id: row._id}).fetch();
+              let path = "";
+              data.forEach((d) => {
+                path = d.path;
+              });
+              let pathEnd = path != null ? path.lastIndexOf("/") : -1;
+              return pathEnd === -1 ? val : path.substring(0, pathEnd + 1) + val;
+            } else {
+              return val;
+            }
+          }},
         {data: "metadata.wfdbdesc.Length", title: "Length",
           render:function(val){
             return val.split(" ")[0];
           }},
-        {data: "_id", title: "Patient #",
+        {data: "_id", title: "Patient #", searchable: false,
           render:function(val){
             //let patient_id = Data.findOne({_id:val}).patient;
             //return Patients.findOne({_id:patient_id}).id;
@@ -30,7 +38,7 @@ TabularTables.Data = new Tabular.Table({
             })
             return patientNum;
           }},
-        {data: "_id", title: "# Assignments", 
+        {data: "_id", title: "# Assignments", searchable: false, 
           render:function(val){
             if(val){
               const data = Data.find({_id: val}).fetch();
@@ -41,7 +49,7 @@ TabularTables.Data = new Tabular.Table({
               return numAssignments;
             }
           }},
-          {data: "_id", title: "# Assignments Completed", 
+          {data: "_id", title: "# Assignments Completed", searchable: false, 
           render:function(val){
             const data = Data.find({_id: val}).fetch();
             let numAssignmentsCompleted = 0;
@@ -50,7 +58,7 @@ TabularTables.Data = new Tabular.Table({
             })
             return numAssignmentsCompleted;
           }},
-          {data: "_id", title: "Assignees", 
+          {data: "_id", title: "Assignees", searchable: false, 
           render:function(val){
             const data = Data.find({_id: val}).fetch();
             let assignees = [];


### PR DESCRIPTION
Rename Path column to Name.

Change provided data back to name instead of id while retaining the path format.

Since search is based on the provided data instead of the rendered data, prevent searching on columns which take the id as data to prevent unexpected behaviour.

Note since the search is based on the provided data and not the formatted data, searching based on the path (e.g. /physionet) will not yield results.