### PR TITLE
CROWDEEG-124 Fix Alignment not Properly Reloading Window

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -4402,6 +4402,8 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
   _reloadCurrentWindow: function () {
     //console.log("_reloadCurrentWindow");
     var that = this;
+    that.vars.annotationsCache = {};
+    that.vars.windowsCache = {};
     // reloads the current window by "switching" to it using the current window start time, the current x axis scale and the current recordings
     that._switchToWindow(
       that.options.allRecordings,


### PR DESCRIPTION
Caches are now properly cleared when aligning the graph (and performing any function that uses _reloadCurrentWindow()