### PR TITLE
CROWDEEG-131 Allow Admins to Create Other Admins

### DIFF
--- a/server/addAdminRole.js
+++ b/server/addAdminRole.js
@@ -1,0 +1,3 @@
+import { Roles } from 'meteor/alanning:roles'
+
+Roles.createRole("admin", {unlessExists: true});


### PR DESCRIPTION
Allows for the admin to assign other users as admin in the Manage section. All that was needed was to add the "admin" as a possible role done in the backend.