### PR TITLE
CROWDEEG-129 Rework Cache

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -4682,46 +4682,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       //stores all "pre loaded" windows
       start_time,
     ];
-    /*if (
-      !that._isCurrentWindowSpecifiedTrainingWindow() &&
-      !that.options.experiment.running &&
-      !that._isInNoTimelockMode() // stop caching windows if in no timelock mode
-    ) {
-      //console.log("5");
-      for (var i = 1; i <= that.options.numberOfForwardWindowsToPrefetch; ++i) {
-        windowsToRequest.push(start_time + i * that.options.windowJumpSizeForwardBackward * window_length);
-      }
-      for (
-        var i = 1;
-        i <= that.options.numberOfFastForwardWindowsToPrefetch;
-        ++i
-      ) {
-        let window = start_time + i * that.options.windowJumpSizeFastForwardBackward * window_length;
-        if (!windowsToRequest.includes(window) && window > 0) {
-          windowsToRequest.push(window);
-        }
-      }
-      for (
-        var i = 1;
-        i <= that.options.numberOfBackwardWindowsToPrefetch;
-        ++i
-      ) {
-        let window = start_time - i * that.options.windowJumpSizeForwardBackward * window_length;
-        if (!windowsToRequest.includes(window) && window > 0) {
-          windowsToRequest.push(window);
-        }
-      }
-      for (
-        var i = 1;
-        i <= that.options.numberOfFastBackwardWindowsToPrefetch;
-        ++i
-      ) {
-        let window = start_time - i * that.options.windowJumpSizeFastForwardBackward * window_length;
-        if (!windowsToRequest.includes(window) && window > 0) {
-          windowsToRequest.push(window);
-        }
-      }
-    }*/
     
     //console.log(that);
     that.vars.reprint = 0;
@@ -4782,35 +4742,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
             that._setBackwardEnabledStatus(false);
             that._setFastBackwardEnabledStatus(false);
           } else {
-            // enable/disable the forward backward buttons according to the current position
-
-
-            switch (windowStartTime) {
-              case that.vars.currentWindowStart + window_length:
-                if (that.options.visibleRegion.end === undefined) {
-                  //console.log('winAva:', windowAvailable);
-                  that._setForwardEnabledStatus(false);
-                }
-
-              case that.vars.currentWindowStart +
-                window_length * that.options.windowJumpSizeFastForwardBackward:
-                if (that.options.visibleRegion.end === undefined) {
-
-                  that._setFastForwardEnabledStatus(false);
-                }
-              // break;
-              case that.vars.currentWindowStart - window_length:
-                if (that.options.visibleRegion.start === undefined) {
-                  that._setBackwardEnabledStatus(false);
-                }
-              // break;
-              case that.vars.currentWindowStart -
-                window_length * that.options.windowJumpSizeFastForwardBackward:
-                if (that.options.visibleRegion.start === undefined) {
-                  that._setFastBackwardEnabledStatus(false);
-                }
-              // break;
-            }
+            that._setForwardEnabledStatus(true);
+            that._setFastForwardEnabledStatus(true);
+            that._setBackwardEnabledStatus(true);
+            that._setFastBackwardEnabledStatus(true);
           }
         }
       }).catch((err) => {
@@ -4981,28 +4916,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       startTime: options.start_time,
       windowLength: options.window_length
     });
-    /*while (Object.keys(that.vars.windowsCache).length >= that.vars.windowsCacheLength) {
-      let keyToDelete = undefined;
-      let farthestKeyDist = -1;
-      Object.keys(that.vars.windowsCache).forEach((key) => {
-        if (!that.vars.windowsCache[key] || !that.vars.windowsCache[key].startTime) {
-          keyToDelete = key;
-          farthestKeyDist = -2;
-        } else if (farthestKeyDist > -2) {
-          if (farthestKeyDist < 0 || Math.abs(options.start_time - that.vars.windowsCache[key].startTime) > farthestKeyDist) {
-            keyToDelete = key;
-            farthestKeyDist = Math.abs(options.start_time - that.vars.windowsCache[key].startTime);
-          }
-        }
-      });
-
-      delete that.vars.windowsCache[keyToDelete];
-    }
-
-    that.vars.windowsCache[identifierKey] = {};
-    // transform the data before storing or displaying them
-    that.vars.windowsCache[identifierKey].promise = promise;
-    that.vars.windowsCache[identifierKey].startTime = options.start_time;*/
   },
 
   /* Options: recordings: allRecordings,
@@ -5037,7 +4950,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     //console.log("identifierKey", identifierKey);
     var noDataError =
       "No data available for window with options " + JSON.stringify(options);
-    console.log("Options", optionsPadded);
 
     if (options.start_time < 0) {
       return Promise.reject("Invalid start time.");
@@ -5061,11 +4973,9 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     // Cache is in sorted order, so first/last elements are at the min/max start time.
     if (!that.vars.windowsCache.length || that.vars.windowsCache[0].startTime > startTime || that.vars.windowsCache[i].startTime + that.vars.windowsCache[i].windowLength < startTime + windowLength) {
       // Total cache miss. This likely means it is a non-local request (i.e. the user jumped to an annotation) so clear the cache completely and reset the area.
-      console.log("Non-local");
       miss = true;
     } else {
       // For now we ensure the cache is contiguous, so as long as the window is between min and max it should be in the cache.
-      console.log("Cache hit", startTime);
       while (i > -1 && that.vars.windowsCache[i].startTime > startTime) {
         i--;
       }
@@ -5119,7 +5029,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
             });
           }
 
-          console.log("Data", realData);
           return realData;
         });
 
@@ -5132,9 +5041,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
           for (let j = 1; j <= replacementLength; j++) {
             windowsToRequest.push(requestStartTime - windowLength * j);
           }
-          console.log("back request", that.vars.windowsCache);
         } else if (index >= that.vars.windowsCacheLength - that.vars.windowsCacheEdgeLength) {
-          console.log("forward request");
           let requestStartTime = that.vars.windowsCache[that.vars.windowsCache.length - 1].startTime + that.vars.windowsCache[that.vars.windowsCache.length - 1].windowLength;
           that.vars.windowsCache = that.vars.windowsCache.slice(replacementLength);
 
@@ -5173,12 +5080,14 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       that.vars.windowsCache = [];
       windowsToRequest = [startTime];
 
-      for (let j = 1; j < Math.ceil(that.vars.windowsCacheLength / 2); j++) {
-        windowsToRequest.push(startTime - windowLength * j);
-      }
+      if (!that._isInNoTimelockMode()) {
+        for (let j = 1; j < Math.ceil(that.vars.windowsCacheLength / 2); j++) {
+          windowsToRequest.push(startTime - windowLength * j);
+        }
 
-      for (let j = 1; j <= Math.floor(that.vars.windowsCacheLength / 2); j++) {
-        windowsToRequest.push(startTime + windowLength * j);
+        for (let j = 1; j <= Math.floor(that.vars.windowsCacheLength / 2); j++) {
+          windowsToRequest.push(startTime + windowLength * j);
+        }
       }
 
       let toReturn = undefined;

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -5036,20 +5036,21 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         });
 
         let windowsToRequest = [];
+        let replacementLength = that.vars.windowsCacheEdgeLength + Math.floor((that.vars.windowsCacheLength - that.vars.windowsCacheEdgeLength * 2) / 4);
         if (index < that.vars.windowsCacheEdgeLength) {
           let requestStartTime = that.vars.windowsCache[0].startTime;
-          that.vars.windowsCache = that.vars.windowsCache.slice(0, that.vars.windowsCacheLength - that.vars.windowsCacheEdgeLength);
+          that.vars.windowsCache = that.vars.windowsCache.slice(0, that.vars.windowsCacheLength - replacementLength);
 
-          for (let j = 1; j <= Math.ceil(that.vars.windowsCacheEdgeLength); j++) {
+          for (let j = 1; j <= replacementLength; j++) {
             windowsToRequest.push(requestStartTime - windowLength * j);
           }
           console.log("back request", that.vars.windowsCache);
         } else if (index >= that.vars.windowsCacheLength - that.vars.windowsCacheEdgeLength) {
           console.log("forward request");
           let requestStartTime = that.vars.windowsCache[that.vars.windowsCache.length - 1].startTime + that.vars.windowsCache[that.vars.windowsCache.length - 1].windowLength;
-          that.vars.windowsCache = that.vars.windowsCache.slice(that.vars.windowsCacheLength - that.vars.windowsCacheEdgeLength);
+          that.vars.windowsCache = that.vars.windowsCache.slice(replacementLength);
 
-          for (let j = 0; j < Math.ceil(that.vars.windowsCacheEdgeLength); j++) {
+          for (let j = 0; j < replacementLength; j++) {
             windowsToRequest.push(requestStartTime + windowLength * j);
           }
         }

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -3298,7 +3298,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     }
   },
 
-  _toggleTimeSyncMode: function (mode) {
+  _toggleTimeSyncMode: function (mode, prevMode) {
     var that = this;
     switch (mode) {
       case "crosshair":
@@ -3308,8 +3308,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         that.options.features.annotationType = "none";
         that._setupAnnotationInteraction();
         $(".timesync").prop("disabled", false);
-        that._toggleNoTimelockScroll(false);
         $(".crosshair-time-input-container").show();
+        if (prevMode === "notimelock") {
+          that._toggleNoTimelockScroll(false);
+        }
         that._displayCrosshair(that.vars.crosshairPosition);
         break;
       case "notimelock":
@@ -3324,7 +3326,9 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         // $(".time_sync").text("");
         $(".timesync").prop("disabled", false);
         $(".crosshair-time-input-container").hide();
-        that._toggleNoTimelockScroll(false);
+        if (prevMode === "notimelock") {
+          that._toggleNoTimelockScroll(false);
+        }
         that._destroyCrosshair();
         break;
       case "undefined":
@@ -3333,8 +3337,10 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         that.options.features.annotationType = that.options.previousAnnotationType;
         that._setupAnnotationInteraction();
         $(".timesync").prop("disabled", true);
+        if (prevMode === "notimelock") {
+          that._toggleNoTimelockScroll(false);
+        }
         $(".crosshair-time-input-container").hide();
-        that._toggleNoTimelockScroll(false);
         that._destroyCrosshair();
         break;
     }
@@ -3488,8 +3494,9 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         if (defaultOptionIndex)
           delete timeSyncOption.options[defaultOptionIndex].default;
         timeSyncOption.options[select.prop("selectedIndex")].default = true;
+        let prevMode = that.vars.timeSyncMode;
         that.vars.timeSyncMode = select.val();
-        that._toggleTimeSyncMode(select.val());
+        that._toggleTimeSyncMode(select.val(), prevMode);
         that._renderAlignmentAlert();
       });
     });
@@ -5076,7 +5083,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
     }
 
     if (miss) {
-      console.log("Total cache miss.");
       that.vars.windowsCache = [];
       windowsToRequest = [startTime];
 

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -4703,25 +4703,25 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
               case that.vars.currentWindowStart + window_length:
                 if (that.options.visibleRegion.end === undefined) {
                   //console.log('winAva:', windowAvailable);
-                  that._setForwardEnabledStatus(true);
+                  that._setForwardEnabledStatus(false);
                 }
 
               case that.vars.currentWindowStart +
                 window_length * that.options.windowJumpSizeFastForwardBackward:
                 if (that.options.visibleRegion.end === undefined) {
 
-                  that._setFastForwardEnabledStatus(true);
+                  that._setFastForwardEnabledStatus(false);
                 }
               // break;
               case that.vars.currentWindowStart - window_length:
                 if (that.options.visibleRegion.start === undefined) {
-                  that._setBackwardEnabledStatus(true);
+                  that._setBackwardEnabledStatus(false);
                 }
               // break;
               case that.vars.currentWindowStart -
                 window_length * that.options.windowJumpSizeFastForwardBackward:
                 if (that.options.visibleRegion.start === undefined) {
-                  that._setFastBackwardEnabledStatus(true);
+                  that._setFastBackwardEnabledStatus(false);
                 }
               // break;
             }
@@ -5059,12 +5059,11 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
           let requestOptions = optionsPadded;
           requestOptions.start_time = window;
           let promise = new Promise((resolve, reject) => {
-            Meteor.call("get.edf.data", optionsPadded, (error, realData) => {
+            Meteor.call("get.edf.data", requestOptions, (error, realData) => {
               if (error) {
                 //console.log(error.message);
                 return reject(error.message);
               }
-              //console.log("edf.data", data);
               if (!that._isDataValid(realData)) {
                 return reject(noDataError);
               } else {
@@ -5099,7 +5098,7 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
         let requestOptions = optionsPadded;
         requestOptions.start_time = window;
         let promise = new Promise((resolve, reject) => {
-          Meteor.call("get.edf.data", optionsPadded, (error, realData) => {
+          Meteor.call("get.edf.data", requestOptions, (error, realData) => {
             if (error) {
               //console.log(error.message);
               return reject(error.message);

--- a/server/EDFBackend.js
+++ b/server/EDFBackend.js
@@ -916,7 +916,6 @@ Meteor.methods({
     options = options || {};
     let startTime = options.start_time || 0;
     let windowLength = options.window_length;
-    let count = 0;
     let maskedChannels = options.maskedChannels;
 
     // this is the original version of codes which display all channels specified in the options:
@@ -1201,7 +1200,11 @@ Meteor.methods({
     let dataDict = {};
     dataFrame.channelInfo.forEach((info, c) => {
       if (!dataDict[info.dataId]) dataDict[info.dataId] = {};
-      dataDict[info.dataId][info.name] = dataFrame.data[c];
+      if (maskedChannels.includes(c)) {
+        dataDict[info.dataId][info.name] = new Float32Array();
+      } else {
+        dataDict[info.dataId][info.name] = dataFrame.data[c];
+      }
     });
 
     // console.log("=====current dataFrame=====");


### PR DESCRIPTION
Completely reworked cache to behave in the following manner:

After a complete cache miss, the cache is populated with promises which eventually resolve to 20 consecutive windows of data, roughly centered on the initial window. Data is drawn from the cache to fulfill requests (if a window spans multiple cached windows, the data is stitched together as needed). When a user gets 'close' to the edge of the cache (currently within 5 windows), the far edge of the cache is removed, and the close edge of the cache is preemptively extended, resulting in a 'rolling' cache.

Additionally, the server only sends unmasked channels, and all windows are re-requested when more channels are unmasked. This results in significantly less data being transmitted by the server, although it has not appeared to speed up response times.

Currently, both edges of the cache are treated equivalently. Given the unidirectional nature of traversal, it would perhaps be more beneficial to extend the edge further in the current direction the user is travelling.