### PR TITLE
CROWDEEG-164 Valid Start Time Checked for Preferences

### DIFF
--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -3926,9 +3926,6 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       .click(function () {
         console.log(Object.keys(that.options.context.preferences.uploadedPreferences.scalingFactors).length);
         console.log(Object.keys(that.vars.originalScalingFactors).length);
-        console.log(that.options.context.preferences.startTime);
-        console.log(that.options.context.preferences);
-        console.log(that.vars);
         //if the scaling factors length of the uploaded file does not match the scaling 
         //factors of the chart, they they are not compatible
         if(that.options.context.preferences.uploadedPreferences.scalingFactors != null){

--- a/client/Annotators/EDF/timeSeriesAnnotator.js
+++ b/client/Annotators/EDF/timeSeriesAnnotator.js
@@ -3926,11 +3926,16 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       .click(function () {
         console.log(Object.keys(that.options.context.preferences.uploadedPreferences.scalingFactors).length);
         console.log(Object.keys(that.vars.originalScalingFactors).length);
+        console.log(that.options.context.preferences.startTime);
+        console.log(that.options.context.preferences);
+        console.log(that.vars);
         //if the scaling factors length of the uploaded file does not match the scaling 
         //factors of the chart, they they are not compatible
         if(that.options.context.preferences.uploadedPreferences.scalingFactors != null){
           if(Object.keys(that.options.context.preferences.uploadedPreferences.scalingFactors).length != Object.keys(that.vars.originalScalingFactors).length){
             window.alert("The preferences file you uploaded is not compatible with the chart (number of channels do not match). Please choose another file.");
+          } else if (that.options.context.preferences.uploadedPreferences.startTime < 0 || that.options.context.preferences.uploadedPreferences.startTime > that.vars.recordingLengthInSeconds) {
+            window.alert("The preferences file you uploaded has an invalid start time (not in the interval of the time series). Please choose another file.");
           } else {
             that._savePreferences(that.options.context.preferences.uploadedPreferences);
             //reload the screen so we can view the changes
@@ -12711,6 +12716,8 @@ $.widget("crowdeeg.TimeSeriesAnnotator", {
       console.log(annotatorConfig);
       if(Object.keys(annotatorConfig.scalingFactors).length != Object.keys(that.vars.originalScalingFactors).length){
         window.alert("The preferences file you wish to upload is not compatible with the chart (number of channels do not match). Please choose another file.");
+      } else if (annotatorConfig.startTime < 0 || annotatorConfig.startTime > that.vars.recordingLengthInSeconds) {
+        window.alert("The preferences file you wish to upload has an invalid start time (not in the interval of the time series). Please choose another file.");
       } else {
         that._savePreferences(annotatorConfig);
         location.reload();


### PR DESCRIPTION
When uploading preferences via file / preference directory during annotation, the start time is checked to make sure it is not negative and that it does not exceed the recording time; otherwise, the file is rejected. These are the only two places where location.reload() is called.