### PR TITLE
changed account revision cap to 250

### DIFF
--- a/collections/index.js
+++ b/collections/index.js
@@ -2488,7 +2488,11 @@ Arbitrations.permit(['insert', 'update', 'remove']).ifHasRole('admin').allowInCl
 Arbitrations.attachCollectionRevisions();
 exports.Arbitrations = Arbitrations;
 
+CollectionRevisions.meteorusers = {
+    keep:250
+}
 Meteor.users.attachCollectionRevisions();
+Meteor.users.attachCollectionRevisions(CollectionRevisions.meteorusers);
 
 // Documentation: https://github.com/yogiben/meteor-admin
 // The admin management page


### PR DESCRIPTION
Added a cap to the number of revisions stored in each account. These revisions essentially just stored the roles a user has and their "last" login date. Some accounts have accumulated up to 6000+ revisions, which is too much for the database to handle when logging on.